### PR TITLE
Problem: travis still won't build fractalide

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,11 +14,11 @@ in (pkgs {
         rustc = nightly.rust;
         inherit (nightly) cargo;
       };
-      racket = if super.stdenv.isDarwin then super.racket.overrideDerivation (drv: {
-        buildInputs = drv.buildInputs ++ [ super.libiconv ];
-        meta = drv.meta.overrideAttrs (attrs: {
-          platforms = attrs.platforms ++ [ "x86_64-darwin" ];
-        });
+      racket = if self.stdenv.isDarwin then super.racket.overrideAttrs (oldAttrs: {
+        buildInputs = oldAttrs.buildInputs ++ [ self.libiconv ];
+        meta = oldAttrs.meta // {
+          platforms = oldAttrs.meta.platforms ++ [ "x86_64-darwin" ];
+        };
       }) else super.racket;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);
       fractalide = self.callPackage ./fractalide.nix {};


### PR DESCRIPTION
overrideDerivation preserves the old meta, so it was never overridden.

Solution: Use overrideAttrs to add darwin to the list of platforms.